### PR TITLE
Escape single quotes in tracked context

### DIFF
--- a/pghistory/tests/test_tracking.py
+++ b/pghistory/tests/test_tracking.py
@@ -89,6 +89,25 @@ def test_track_context_id(mocker):
 
 
 @pytest.mark.django_db
+def test_track_context_metadata_single_quote(mocker):
+    """
+    Verifies that context metadata with single quotes is properly
+    escaped
+    """
+    with pghistory.context(key1="can't", key2="''quoted''",) as ctx:
+        # Creating the EventModel will trigger an event, which will
+        # attach the current context
+        ddf.G('tests.EventModel')
+
+        ctx1 = pghistory.models.Context.objects.get()
+        assert ctx1.id == ctx.id
+        assert ctx1.metadata == {
+            'key1': "can't",
+            'key2': "''quoted''",
+        }
+
+
+@pytest.mark.django_db
 def test_track_context_metadata(mocker):
     """
     Verifies that the proper metadata is attached to a tracked event

--- a/pghistory/tracking.py
+++ b/pghistory/tracking.py
@@ -37,9 +37,13 @@ def _inject_history_context(sql, sql_vars, cursor):
         # setting. Ignore this specific statement for now
         return None
 
+    # Metadata is stored as a serialized JSON string with escaped
+    # single quotes
+    metadata_str = json.dumps(_tracker.value.metadata).replace("'", "''")
+
     sql = (
         f'SET LOCAL pghistory.context_id=\'{_tracker.value.id}\';'
-        f'SET LOCAL pghistory.context_metadata=\'{json.dumps(_tracker.value.metadata)}\';'
+        f'SET LOCAL pghistory.context_metadata=\'{metadata_str}\';'
     ) + sql
 
     return sql, sql_vars

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.black]
 line-length = 79
-target-version = ['py36']
+target-version = ['py38']
 skip-string-normalization = true
 
 [tool.poetry]


### PR DESCRIPTION
Invalid SQL was generated from context values with single quotes when
using ``pghistory.context``. Single quotes are now properly escaped, and
a failing test case was created to cover this scenario.

Type: bug

@tomage this addresses #2 

Although it is possible to pass in the context variable as a SQL var and then let mogrify handle this, I'm hesitant to populate the SQL variables of the hook since the fix is to simply escape the single quote. Single quotes in postgres are escaped with another single quote.

I wrote a failing test case for this scenario and verified the fix